### PR TITLE
Add support for a minimum runtime

### DIFF
--- a/src/AsyncTestCase.php
+++ b/src/AsyncTestCase.php
@@ -13,7 +13,7 @@ use function Amp\call;
 abstract class AsyncTestCase extends PHPUnitTestCase
 {
 
-    private const RUNTIME_PRECISION = 2;
+    const RUNTIME_PRECISION = 2;
 
     private $timeoutId;
 

--- a/src/AsyncTestCase.php
+++ b/src/AsyncTestCase.php
@@ -48,7 +48,7 @@ abstract class AsyncTestCase extends PHPUnitTestCase
                     if ($this->minimumRuntime) {
                         if ($this->minimumRuntime > $actualRuntime) {
                             $msg = 'Expected test to take at least %dms but instead took %dms';
-                            $this->fail(sprintf($msg, $this->minimumRuntime, $actualRuntime));
+                            $this->fail(\sprintf($msg, $this->minimumRuntime, $actualRuntime));
                         }
                     }
                 } finally {

--- a/src/AsyncTestCase.php
+++ b/src/AsyncTestCase.php
@@ -12,7 +12,6 @@ use function Amp\call;
  */
 abstract class AsyncTestCase extends PHPUnitTestCase
 {
-
     const RUNTIME_PRECISION = 2;
 
     private $timeoutId;

--- a/src/LoopReset.php
+++ b/src/LoopReset.php
@@ -11,6 +11,6 @@ class LoopReset extends BaseTestListener
     public function endTest(Test $test, $time)
     {
         Loop::set((new Loop\DriverFactory)->create());
-        gc_collect_cycles(); // extensions using an event loop may otherwise leak the file descriptors to the loop
+        \gc_collect_cycles(); // extensions using an event loop may otherwise leak the file descriptors to the loop
     }
 }

--- a/test/AsyncTestCaseTest.php
+++ b/test/AsyncTestCaseTest.php
@@ -10,7 +10,6 @@ use function Amp\call;
 
 class AsyncTestCaseTest extends AsyncTestCase
 {
-
     public function testThatMethodRunsInLoopContext()
     {
         $returnDeferred = new Deferred(); // make sure our test runs to completion

--- a/test/AsyncTestCaseTest.php
+++ b/test/AsyncTestCaseTest.php
@@ -77,7 +77,8 @@ class AsyncTestCaseTest extends AsyncTestCase
         $this->assertTrue($baz);
     }
 
-    public function testSetMinimumRunTime() {
+    public function testSetMinimumRunTime()
+    {
         $this->setMinimumRuntime(100);
         $func = function() {
             yield new Delayed(110);

--- a/test/AsyncTestCaseTest.php
+++ b/test/AsyncTestCaseTest.php
@@ -77,4 +77,16 @@ class AsyncTestCaseTest extends AsyncTestCase
         $this->assertTrue($baz);
     }
 
+    public function testSetMinimumRunTime() {
+        $this->setMinimumRuntime(100);
+        $func = function() {
+            yield new Delayed(110);
+            return 'finished';
+        };
+
+        $finished = yield call($func);
+
+        $this->assertSame('finished', $finished);
+    }
+
 }

--- a/test/AsyncTestCaseTest.php
+++ b/test/AsyncTestCaseTest.php
@@ -89,5 +89,4 @@ class AsyncTestCaseTest extends AsyncTestCase
 
         $this->assertSame('finished', $finished);
     }
-
 }

--- a/test/AsyncTestCaseTest.php
+++ b/test/AsyncTestCaseTest.php
@@ -80,7 +80,7 @@ class AsyncTestCaseTest extends AsyncTestCase
     public function testSetMinimumRunTime()
     {
         $this->setMinimumRuntime(100);
-        $func = function() {
+        $func = function () {
             yield new Delayed(110);
             return 'finished';
         };

--- a/test/AsyncTestCaseTest.php
+++ b/test/AsyncTestCaseTest.php
@@ -7,6 +7,7 @@ use Amp\Delayed;
 use Amp\Loop;
 use Amp\PHPUnit\AsyncTestCase;
 use function Amp\call;
+use PHPUnit\Framework\AssertionFailedError;
 
 class AsyncTestCaseTest extends AsyncTestCase
 {
@@ -80,12 +81,12 @@ class AsyncTestCaseTest extends AsyncTestCase
     {
         $this->setMinimumRuntime(100);
         $func = function () {
-            yield new Delayed(110);
+            yield new Delayed(75);
             return 'finished';
         };
 
-        $finished = yield call($func);
-
-        $this->assertSame('finished', $finished);
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessageRegExp("/Expected test to take at least 100ms but instead took (\d+)ms/");
+        yield call($func);
     }
 }

--- a/test/AsyncTestCaseTest.php
+++ b/test/AsyncTestCaseTest.php
@@ -6,8 +6,8 @@ use Amp\Deferred;
 use Amp\Delayed;
 use Amp\Loop;
 use Amp\PHPUnit\AsyncTestCase;
-use function Amp\call;
 use PHPUnit\Framework\AssertionFailedError;
+use function Amp\call;
 
 class AsyncTestCaseTest extends AsyncTestCase
 {


### PR DESCRIPTION
As [requested in the StackOverflow chat room](https://chat.stackoverflow.com/transcript/message/45322171#45322171) this PR adds support for ensuring that a test has a minimum runtime. The calculation for determining that runtime was taken from the original implementation in `TestCase`.

I'm a bit stumped on how to properly test this functionality... you can see the appropriate failure message that is expected by adjusting the amount of time that is delayed in the test unit test.