### PR TITLE
PHPUnit 9 supported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 composer.lock
 phpunit.xml
 vendor
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "irc": "irc://irc.freenode.org/amphp"
     },
     "require": {
-        "phpunit/phpunit": "^6 | ^7 | ^8"
+        "phpunit/phpunit": "^6 | ^7 | ^8 | ^9"
     },
     "require-dev": {
         "amphp/amp": "^2",

--- a/test/AsyncTestCaseTest.php
+++ b/test/AsyncTestCaseTest.php
@@ -132,7 +132,14 @@ class AsyncTestCaseTest extends AsyncTestCase
         };
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessageRegExp("/Expected test to take at least 100ms but instead took (\d+)ms/");
+        $pattern = "/Expected test to take at least 100ms but instead took (\d+)ms/";
+        if (\method_exists($this, 'expectExceptionMessageMatches')) {
+            // PHPUnit 8+
+            $this->expectExceptionMessageMatches($pattern);
+        } else {
+            // PHPUnit 6-7
+            $this->expectExceptionMessageRegExp($pattern);
+        }
         yield call($func);
     }
 


### PR DESCRIPTION
Method `\PHPUnit\Framework\TestCase::expectExceptionMessageRegExp()` doesn't exist in PHPUnit 9 anymore, so I've done a small workaround for the tests to pass. The alternative is to drop support for PHPUnit 6-7 (and for PHP before 7.2, because PHPUnit 8.0 supports PHP 7.2+).