### PR TITLE
Add setUpAsync() and tearDownAsync()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,16 @@
-sudo: false
+os: linux
 
 language: php
 
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
   - nightly
 
-matrix:
+jobs:
   allow_failures:
-    - php: 7.4snapshot
     - php: nightly
   fast_finish: true
 
@@ -21,15 +19,15 @@ env:
 
 install:
   - composer update -n --prefer-dist
-  - wget https://github.com/php-coveralls/php-coveralls/releases/download/v1.0.2/coveralls.phar
-  - chmod +x coveralls.phar
 
 script:
   - vendor/bin/phpunit --coverage-text --coverage-clover build/logs/clover.xml
   - PHP_CS_FIXER_IGNORE_ENV=1 php vendor/bin/php-cs-fixer --diff --dry-run -v fix
 
 after_script:
-  - ./coveralls.phar -v
+  - wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.2.0/php-coveralls.phar
+  - chmod +x php-coveralls.phar
+  - travis_retry ./php-coveralls.phar -v
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "irc": "irc://irc.freenode.org/amphp"
     },
     "require": {
+        "php": ">=7.1",
         "phpunit/phpunit": "^6 | ^7 | ^8 | ^9"
     },
     "require-dev": {

--- a/src/AsyncTestCase.php
+++ b/src/AsyncTestCase.php
@@ -94,10 +94,10 @@ abstract class AsyncTestCase extends PHPUnitTestCase
     private function runAsyncTestCycle(array $args): \Generator
     {
         try {
-            yield $this->setUpAsync();
+            yield $this->call(\Closure::fromCallable([$this, 'setUpAsync']));
         } catch (\Throwable $exception) {
             throw new \Error(\sprintf(
-                'Promise returned from %s::setUpAsync() failed',
+                '%s::setUpAsync() failed',
                 \str_replace("\0", '@', \get_class($this)) // replace NUL-byte in anonymous class name
             ), 0, $exception);
         }
@@ -109,10 +109,10 @@ abstract class AsyncTestCase extends PHPUnitTestCase
         }
 
         try {
-            yield $this->tearDownAsync();
+            yield $this->call(\Closure::fromCallable([$this, 'tearDownAsync']));
         } catch (\Throwable $exception) {
             throw new \Error(\sprintf(
-                'Promise returned from %s::tearDownAsync() failed',
+                '%s::tearDownAsync() failed',
                 \str_replace("\0", '@', \get_class($this)) // replace NUL-byte in anonymous class name
             ), 0, $exception);
         } finally {
@@ -130,14 +130,22 @@ abstract class AsyncTestCase extends PHPUnitTestCase
         return parent::runTest();
     }
 
-    protected function setUpAsync(): Promise
+    /**
+     * Called before each test. Similar to {@see TestCase::setUp()}, except the method may return a promise or
+     * coroutine (@see \Amp\call()} that will be awaited before executing the test.
+     */
+    protected function setUpAsync()
     {
-        return new Success;
+        // Empty method to be overloaded by inheriting class if desired.
     }
 
-    protected function tearDownAsync(): Promise
+    /**
+     * Called after each test. Similar to {@see TestCase::tearDown()}, except the method may return a promise or
+     * coroutine (@see \Amp\call()} that will be awaited before executing the next test.
+     */
+    protected function tearDownAsync()
     {
-        return new Success;
+        // Empty method to be overloaded by inheriting class if desired.
     }
 
     /**

--- a/src/AsyncTestCase.php
+++ b/src/AsyncTestCase.php
@@ -10,7 +10,6 @@ use Amp\Success;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 use React\Promise\PromiseInterface as ReactPromise;
-use function Amp\call;
 
 /**
  * A PHPUnit TestCase intended to help facilitate writing async tests by running each test as coroutine with Amp's
@@ -57,36 +56,7 @@ abstract class AsyncTestCase extends PHPUnitTestCase
         $start = \microtime(true);
 
         Loop::run(function () use (&$returnValue, &$exception, &$invoked, $args) {
-            $promise = call(function () use ($args) {
-                try {
-                    yield $this->setUpAsync();
-                } catch (\Throwable $exception) {
-                    throw new \Error(\sprintf(
-                        'Promise returned from %s::setUpAsync() failed',
-                        \str_replace("\0", '@', \get_class($this)) // replace NUL-byte in anonymous class name
-                    ), 0, $exception);
-                }
-
-                try {
-                    yield $this->call([$this, $this->realTestName], ...$args);
-                } catch (\Throwable $testException) {
-                    // Exception rethrown in finally block below
-                }
-
-                try {
-                    yield $this->tearDownAsync();
-                } catch (\Throwable $exception) {
-                    throw new \Error(\sprintf(
-                        'Promise returned from %s::tearDownAsync() failed',
-                        \str_replace("\0", '@', \get_class($this)) // replace NUL-byte in anonymous class name
-                    ), 0, $exception);
-                } finally {
-                    if (isset($testException)) {
-                        throw $testException;
-                    }
-                }
-            });
-
+            $promise = new Coroutine($this->runAsyncTestCycle($args));
             $promise->onResolve(function ($error, $value) use (&$invoked, &$exception, &$returnValue) {
                 $invoked = true;
                 $exception = $error;
@@ -116,6 +86,39 @@ abstract class AsyncTestCase extends PHPUnitTestCase
                 $actualRuntime,
                 \sprintf($msg, $this->minimumRuntime, $actualRuntime)
             );
+        }
+
+        return $returnValue;
+    }
+
+    private function runAsyncTestCycle(array $args): \Generator
+    {
+        try {
+            yield $this->setUpAsync();
+        } catch (\Throwable $exception) {
+            throw new \Error(\sprintf(
+                'Promise returned from %s::setUpAsync() failed',
+                \str_replace("\0", '@', \get_class($this)) // replace NUL-byte in anonymous class name
+            ), 0, $exception);
+        }
+
+        try {
+            $returnValue = yield $this->call([$this, $this->realTestName], ...$args);
+        } catch (\Throwable $testException) {
+            // Exception rethrown in finally block below
+        }
+
+        try {
+            yield $this->tearDownAsync();
+        } catch (\Throwable $exception) {
+            throw new \Error(\sprintf(
+                'Promise returned from %s::tearDownAsync() failed',
+                \str_replace("\0", '@', \get_class($this)) // replace NUL-byte in anonymous class name
+            ), 0, $exception);
+        } finally {
+            if (isset($testException)) {
+                throw $testException;
+            }
         }
 
         return $returnValue;

--- a/test/AsyncTestCaseTest.php
+++ b/test/AsyncTestCaseTest.php
@@ -42,6 +42,13 @@ class AsyncTestCaseTest extends AsyncTestCase
         $this->assertTrue($testData->val, 'Expected our test to run on loop to completion');
     }
 
+    public function testReturningPromise(): Promise
+    {
+        $returnValue = new Delayed(100, 'value');
+        $this->assertInstanceOf(Promise::class, $returnValue); // An assertion is required for the test to pass
+        return $returnValue; // Return value used by testReturnValueFromDependentTest
+    }
+
     public function testExpectingAnExceptionThrown(): \Generator
     {
         $throwException = function () {
@@ -95,6 +102,16 @@ class AsyncTestCaseTest extends AsyncTestCase
         $this->assertSame('foo', $foo);
         $this->assertSame(42, $bar);
         $this->assertTrue($baz);
+    }
+
+    /**
+     * @param string|null $value
+     *
+     * @depends testReturningPromise
+     */
+    public function testReturnValueFromDependentTest(string $value = null)
+    {
+        $this->assertSame('value', $value);
     }
 
     public function testSetTimeout(): \Generator

--- a/test/AsyncTestCaseWithSetUpAndTearDownTest.php
+++ b/test/AsyncTestCaseWithSetUpAndTearDownTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Amp\PHPUnit\Test;
+
+use Amp\Failure;
+use Amp\PHPUnit\AsyncTestCase;
+use Amp\PHPUnit\TestException;
+use Amp\Promise;
+
+class AsyncTestCaseWithSetUpAndTearDownTest extends AsyncTestCase
+{
+    private static $firstRun = true;
+
+    protected function setUpAsync(): Promise
+    {
+        if (self::$firstRun) {
+            self::$firstRun = false;
+            return parent::setUpAsync();
+        }
+
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('setUpAsync() failed');
+
+        return new Failure(new TestException);
+    }
+
+    protected function tearDownAsync(): Promise
+    {
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('tearDownAsync() failed');
+
+        return new Failure(new TestException);
+    }
+
+    public function testFailingTearDownAsync()
+    {
+        // Expected exception set in tearDownAsync().
+    }
+
+    public function testFailingSetUpAsync()
+    {
+        // Expected exception set in setUpAsync().
+    }
+}

--- a/test/AsyncTestCaseWithSetUpAndTearDownTest.php
+++ b/test/AsyncTestCaseWithSetUpAndTearDownTest.php
@@ -6,6 +6,7 @@ use Amp\Failure;
 use Amp\PHPUnit\AsyncTestCase;
 use Amp\PHPUnit\TestException;
 use Amp\Promise;
+use Amp\Success;
 
 class AsyncTestCaseWithSetUpAndTearDownTest extends AsyncTestCase
 {
@@ -18,7 +19,7 @@ class AsyncTestCaseWithSetUpAndTearDownTest extends AsyncTestCase
             return new Failure(new TestException);
         }
 
-        return parent::setUpAsync();
+        return new Success;
     }
 
     protected function tearDownAsync(): Promise
@@ -30,7 +31,7 @@ class AsyncTestCaseWithSetUpAndTearDownTest extends AsyncTestCase
             return new Failure(new TestException);
         }
 
-        return parent::tearDownAsync();
+        return new Success;
     }
 
     public function testExpectedException(): void

--- a/test/AsyncTestCaseWithSetUpAndTearDownTest.php
+++ b/test/AsyncTestCaseWithSetUpAndTearDownTest.php
@@ -9,27 +9,36 @@ use Amp\Promise;
 
 class AsyncTestCaseWithSetUpAndTearDownTest extends AsyncTestCase
 {
-    private static $firstRun = true;
-
     protected function setUpAsync(): Promise
     {
-        if (self::$firstRun) {
-            self::$firstRun = false;
-            return parent::setUpAsync();
+        if ($this->getName() === 'testFailingSetUpAsync') {
+            $this->expectException(\Error::class);
+            $this->expectExceptionMessage('setUpAsync() failed');
+
+            return new Failure(new TestException);
         }
 
-        $this->expectException(\Error::class);
-        $this->expectExceptionMessage('setUpAsync() failed');
-
-        return new Failure(new TestException);
+        return parent::setUpAsync();
     }
 
     protected function tearDownAsync(): Promise
     {
-        $this->expectException(\Error::class);
-        $this->expectExceptionMessage('tearDownAsync() failed');
+        if ($this->getName() === 'testFailingTearDownAsync') {
+            $this->expectException(\Error::class);
+            $this->expectExceptionMessage('tearDownAsync() failed');
 
-        return new Failure(new TestException);
+            return new Failure(new TestException);
+        }
+
+        return parent::tearDownAsync();
+    }
+
+    public function testExpectedException(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Test exception');
+
+        throw new \Exception('Test exception');
     }
 
     public function testFailingTearDownAsync()


### PR DESCRIPTION
As requested by @prolic, this PR adds async versions of `setUp()` and `tearDown()`, aptly named `setUpAsync()` and `tearDownAsync()`.